### PR TITLE
various fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 public/lib/*
 public/js/*
-test/*
-view/*
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ view/atlasmaker/_resources/
 view/atlasmaker/src/html/_img-all/
 view/atlasmaker/src/tools/and_label.js
 view/brainbox/_resources/
+/.nyc_output

--- a/test/unit/atlasmakerServer.test.js
+++ b/test/unit/atlasmakerServer.test.js
@@ -11,19 +11,13 @@ const U = require('../utils.js');
 const { expect } = require('chai');
 require('mocha-sinon');
 
-// console.log("Current directory:", __dirname);
-// const { exec } = require("child_process");
-// exec('ls -l', (error, stdout, std_err) => {
-//   console.log(stdout);
-// });
-
 describe('UNIT TESTING ATLASMAKER SERVER', function () {
   describe('MRI IO', function () {
     let mri1, mri2;
 
     it('Should load a nii.gz file', async function () {
       mri1 = await amri.readNifti(datadir + 'bert_brain.nii.gz');
-    });
+    }).timeout(U.mediumTimeout);
 
     it('Should get the dimensions right', function () {
       assert(mri1.dim[0] === 256 && mri1.dim[1] === 256 && mri1.dim[2] === 256);
@@ -61,7 +55,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
   // Function to test loadMRI function on different inputs
   describe('loadMRI function ', function () {
     it('should load the contents of .nii.gz file when a valid path is passed', async function (done) {
-      const path = __dirname.split('/unit')[0] + '/data/bert_brain.nii.gz';
+      const path = datadir + 'bert_brain.nii.gz';
       amri.loadMRI(path).then((res) => {
         expect(res).to.not.eql(null);
         expect(res).to.haveOwnProperty('dim');
@@ -84,7 +78,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
     });
 
     it('should load the contents of .mgz file when a valid path is passed', async function (done) {
-      const path = __dirname.split('/unit')[0] + '/data/001.mgz';
+      const path = datadir + '001.mgz';
       amri.loadMRI(path).then((res) => {
         expect(res).to.not.eql(null);
         expect(res).to.haveOwnProperty('dim');
@@ -184,13 +178,13 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
       it('should return correct value if the mri path is valid and not being used', async function () {
         let ws = new WebSocket({ port: 8081 });
         await AMS._connectNewUser({ ws: ws });
-        const path = __dirname.split('/unit')[0] + '/data/001.mgz';
+        const path = datadir + '001.mgz';
         await amri.loadMRI(path);
         const users = await AMS.numberOfUsersConnectedToMRI(path);
         await AMS._disconnectUser({ ws: ws });
         ws.close();
         assert.strictEqual(users, 0);
-      });
+      }).timeout(U.longTimeout);
     });
 
     describe('displayUsers function() ', function () {
@@ -233,7 +227,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
       });
 
       it('should display the brains when there are some brains loaded', async function () {
-        let path = __dirname.split('/unit')[0] + '/data/001.mgz';
+        let path = datadir + '001.mgz';
         let brain = await AMS.getBrainAtPath(path);
         await AMS.displayBrains();
         let cnt = 0;
@@ -243,7 +237,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
         }
         await AMS.unloadMRI(path);
         assert.strictEqual(cnt, 1);
-      });
+      }).timeout(U.mediumTimeout);;
     });
 
     describe('getBrainAtPath function() ', function () {
@@ -254,7 +248,7 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
       });
 
       it('should load the brain if the path is valid', function (done) {
-        const path = __dirname.split('/unit')[0] + '/data/001.mgz';
+        const path = datadir + '001.mgz';
         AMS.getBrainAtPath(path).then((res) => {
           console.log(res);
           expect(res).to.not.eql(null);
@@ -278,27 +272,27 @@ describe('UNIT TESTING ATLASMAKER SERVER', function () {
     });
 
     describe('_connectNewUser() function ', function () {
-      it('should connect the user when the web socket is passed', async function() {
+      it('should connect the user when the web socket is passed', async function () {
         let ws = new WebSocket({ port: 8081 });
         await AMS._connectNewUser({ ws: ws });
         let cnt = 0;
-        for(var x = 0; x < AMS.US.length; x++) {
-          if(AMS.US[x])
+        for (var x = 0; x < AMS.US.length; x++) {
+          if (AMS.US[x])
             cnt++;
         }
-        await AMS._disconnectUser({ws: ws});
+        await AMS._disconnectUser({ ws: ws });
         ws.close();
         assert.strictEqual(cnt, 1);
       });
     });
     describe('removeUser() function ', function () {
-      it('should remove the user with the provided websocket', async function() {
+      it('should remove the user with the provided websocket', async function () {
         let ws = new WebSocket({ port: 8081 });
         await AMS._connectNewUser({ ws: ws });
         await AMS.removeUser(ws);
         let cnt = 0;
-        for(var x = 0; x < AMS.US.length; x++) {
-          if(AMS.US[x])
+        for (var x = 0; x < AMS.US.length; x++) {
+          if (AMS.US[x])
             cnt++;
         }
         ws.close();


### PR DESCRIPTION
<!-- Thank you for your contribution to BrainBox -->

<!-- Give a short title and description for your pull request: -->

---
<!-- Run the tests. Replace each `[ ]` by `[X]` when the step is complete.-->
- [ ] These changes fix #__ (github issue number if applicable).
- [ ] ```npm run mocha-test``` ran with full success.
- [ ] ```npm run mocha-test``` ran resulted in  failure in _____

<!-- Replace `__` with appropriate information: -->
- [ ] I implemented tests for the changes I made OR
- [ ] These changes do not require tests because _____

<!-- Make sure that "Allow edits from maintainers" checkbox is checked.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification. -->


- [ ] All BrainBox tools behave as expected:
    * **KEYS**
        * right and left arrow keys
            - [ ] jump to next or previous slice within one brain, respectively
            - [ ] update the slider accordingly
            - [ ] update the slice number accordingly (upper left corner of the viewer window)
        * down and up arrow keys
            - [ ] jump to the next or previous brain within one project, respectively
            - [ ] update the selected subject in the annotation table
    * **TOOL BUTTONS**
        * minus
            - [ ] jumps to the previous slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * plus
            - [ ] jumps to the next slice within one brain
            - [ ] updates the slider accordingly
            - [ ] updates the slice number accordingly (upper left corner of the viewer window)
        * slider
            - [ ] updates slice view and slice number on the fly
        * sag / cor / axi buttons
            - [ ] switch view between the three orthogonal planes
        * show tool
            - [ ] when you click and drag in your browser window, this tool displays a cirlce at the position of your mouse click & drag as well as the user name in all browser windows connected to the same brain
        * the numbers at the bottom of the tool panel
            - [ ] change pencil size and eraser size accordingly
        * pencil tool
            - [ ] draws a line in the colour displayed in the color field
            - [ ] in combination with bucket tool filles a complete area with the chosen colour (be sure to have closed the contour line ;) Otherwise, the undo button will be your friend ;)
            - [ ] updates length and volume information (of what has been segmented) in the upper left corner of the viewer
        * erase tool
            - [ ] erases upon click drag from the annotation
            - [ ] in combination with the bucket tool erases the complete area of the color where you click
        * fill bucket tool
            * in combination with pencil tool
                - [ ] fills a complete area with the colour displayed in the colour field
            * in combination with erase tool
                - [ ] erases the complete area that is filled by the colour of where you click
        * colour field
            - [ ] displays the currently chosen colour to draw and fill
            - [ ] on click opens the set of colours available within the chosen label set where a new colour can be selected upon click
        * ruler tool
            - [ ] measures the distance between start and end of your defined path
                - [ ] points of mouse click appear and stay visible until you hit return key (this functionality is currently broken!) (you can click as many points as you wish to define the path you are interested in)
                - [ ] on return key, BrainBox will print the distance into the chat field (the ruler tool seems to be currently broken!!!)
        * adjust tool
            - [ ] slide opacity of overlaid annotation from 0 to 100%
            - [ ] increase or decrease brightness of the underlying MRI data
            - [ ] increase or decrease the contrast of the underlying MRI data
        * eyedropper tool
            - [ ] updates the colour field in the tool panel
            - [ ] displays/updates the region name in the upper left corner of the viewer
        * undo tool
            - [ ] undoes the user's actions in reverse chronological order and currently has the bug that it even undoes actions in slices you are currently not seeing! and there is currently no redo...
        * save button
            - [ ] saves the annotation of the data set into the data base
            - [ ] displays a message that user needs to login in case they are not
            - [ ] display a message `Atlas saved Wed Oct 18 2017 12:49:12 GMT+0200 (CEST)`


